### PR TITLE
Improve line-spacing, decrease font size on small screens, fix issue #15

### DIFF
--- a/_sass/moving.scss
+++ b/_sass/moving.scss
@@ -2,11 +2,13 @@
 
 // Define defaults for each variable.
 
-$base-font-family: "Bitter", "Times New Roman", "FangSong", "仿宋", STFangSong, "华文仿宋", serif;
+$base-font-family: "Bitter", "Times New Roman", "FangSong", "仿宋", STFangSong,
+  "华文仿宋", serif;
 $base-font-size: 18px !default;
 $base-font-weight: 400 !default;
-$small-font-size: $base-font-size * 0.9 !default;
-$base-line-height: 1.5 !default;
+$small-font-size: $base-font-size * 0.85 !default;
+$base-line-height: 1.8 !default;
+$small-line-height: 1.6 !default;
 
 $spacing-unit: 30px !default;
 

--- a/_sass/moving/_base.scss
+++ b/_sass/moving/_base.scss
@@ -25,7 +25,7 @@ figure {
   * Basic styling
   */
 body {
-  font: $base-font-weight #{$base-font-size}/#{$base-line-height}
+  font: $base-font-weight #{$small-font-size}/#{$small-line-height}
     $base-font-family;
   color: $text-color;
   background-color: $background-color;
@@ -38,7 +38,13 @@ body {
   display: flex;
   min-height: 100vh;
   flex-direction: column;
-  padding: 0 5%;
+  padding: 0 2%;
+
+  @media screen and (min-width: $on-medium) {
+    padding: 0 5%;
+    font: $base-font-weight #{$base-font-size}/#{$base-line-height}
+      $base-font-family;
+  }
 }
 
 /**

--- a/_sass/moving/_layout.scss
+++ b/_sass/moving/_layout.scss
@@ -173,13 +173,14 @@
   margin-left: 0;
   list-style: none;
 
-  > li {
-    margin-bottom: $spacing-unit / 3;
+  li {
+    margin-bottom: $spacing-unit / 6;
   }
 }
 
 .post-year {
-  margin-top: 1rem;
+  margin-top: 2rem;
+  margin-bottom: 0.25rem;
   font-weight: 700;
   color: lighten($text-color, 15%);
 
@@ -192,6 +193,7 @@
 
 .post-meta {
   display: inline-block;
+  min-width: 60px;
 
   @media (max-width: 500px) {
     @include relative-font-size(0.8);
@@ -203,7 +205,7 @@
 
 .post-link-layout {
   margin-left: 10%;
-  display: inline-block;
+  display: inline;
 
   @media (max-width: 500px) {
     @include relative-font-size(1);
@@ -237,8 +239,7 @@
 .post-title,
 .post-content h1 {
   @include relative-font-size(2.2);
-  letter-spacing: -1px;
-  line-height: 1;
+  line-height: 1.3;
   font-weight: 1000;
   margin-top: -0.5rem;
 
@@ -283,7 +284,7 @@
 .social-media-list {
   margin-top: -0.6rem;
   display: flex;
-  @include relative-font-size(1.0);
+  @include relative-font-size(1);
   li {
     float: left;
     a {


### PR DESCRIPTION
Small tweaks to the typography just to make it easier to read. Increased the line-height across all screen sizes, and reduced the base font-size on smaller screens. 

Before: 
<img width="790" alt="Screenshot 2019-08-27 at 15 58 57" src="https://user-images.githubusercontent.com/12171243/63782769-ce8d2a00-c8e3-11e9-8ff4-69d8e5c1b7de.png">

After: 
<img width="790" alt="Screenshot 2019-08-27 at 15 58 18" src="https://user-images.githubusercontent.com/12171243/63782784-d64cce80-c8e3-11e9-894a-326b909f5ba7.png">

Also added a min-width to the .post-meta class on the home page, so that the titles to the right are aligned (as mentioned in issue #15 ), and increased the spacing between post titles to improve the tap-target size (particularly important on mobile).

Before: 
<img width="417" alt="Screenshot 2019-08-27 at 16 02 11" src="https://user-images.githubusercontent.com/12171243/63783097-4e1af900-c8e4-11e9-8367-501177a34fd1.png">

After:
<img width="439" alt="Screenshot 2019-08-27 at 16 02 00" src="https://user-images.githubusercontent.com/12171243/63783115-53784380-c8e4-11e9-908d-6d6b44697a5c.png">
