### PR TITLE
Add Stackbit

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ Your theme is setup just like a normal Jekyll site! To test your theme, run `bun
 When your theme is released, only the files in `_layouts`, `_includes`, `_sass` and `assets` tracked with Git will be bundled.
 To add a custom directory to your theme-gem, please edit the regexp in `moving.gemspec` accordingly.
 
+## Stackbit Deploy
+
+This theme is ready to import into Stackbit in 1 click. This theme can be deployed to Netlify and you can connect any headless CMS including Forestry, NetlifyCMS, DatoCMS or Contentful. 
+
+[![Create with Stackbit](https://assets.stackbit.com/badge/create-with-stackbit.svg)](https://app.stackbit.com/create?theme=https://github.com/huangyz0918/moving)
+
 ## License
 
 The theme is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 title: Moving # The title of the blog
 author: Your Name # Your name 
 email: your-email@domain.com # your email shown in the footer
-url: http://huangyz.name/moving/ # this is your site's root address.
+url: "/" # this is your site's root address.
 description: > # this means to ignore newlines until "show_excerpts:"
   A clean and minimalist theme for Jekyll.
 favicon: "./favicon.ico" # set the favicon of the site 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,7 +6,7 @@
           <ul class="contact-list">
             <li class="p-name">
               {%- if site.author -%}
-                <a class="black-link" href="{{ site.url | relative_url }}/about.html">
+                <a class="black-link" href="{{ site.url }}about.html">
                   {{ site.author | escape }} 
                 </a>
               {%- endif -%}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,7 +6,7 @@
           <ul class="contact-list">
             <li class="p-name">
               {%- if site.author -%}
-                <a class="black-link" href="{{ site.url }}/about.html">
+                <a class="black-link" href="{{ site.url | relative_url }}/about.html">
                   {{ site.author | escape }} 
                 </a>
               {%- endif -%}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,9 +3,9 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   {%- seo title=false -%}
-  <link rel="stylesheet" href="{{ site.url }}/assets/css/main.css" />
+  <link rel="stylesheet" href="/assets/css/main.css" />
   <link rel="shortcut icon" type="image/x-icon" href="{{ site.favicon }}" />
-  <link rel="stylesheet" href="{{ site.url }}/assets/css/agate.css" />
+  <link rel="stylesheet" href="/assets/css/agate.css" />
   <script src="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.4.0/highlight.min.js"></script>
   <script>
     hljs.initHighlightingOnLoad();

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,9 +3,9 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   {%- seo title=false -%}
-  <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="stylesheet" href="{{ site.url }}assets/css/main.css" />
   <link rel="shortcut icon" type="image/x-icon" href="{{ site.favicon }}" />
-  <link rel="stylesheet" href="/assets/css/agate.css" />
+  <link rel="stylesheet" href="{{ site.url }}assets/css/agate.css" />
   <script src="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.4.0/highlight.min.js"></script>
   <script>
     hljs.initHighlightingOnLoad();

--- a/moving.gemspec
+++ b/moving.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "jekyll-feed", "~> 0.9"
   spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.1"
 
-  spec.add_development_dependency "bundler", "~> 2.0.2"
+  spec.add_development_dependency "bundler", "2.0.1"
   spec.add_development_dependency "rake", "~> 12.0"
 end

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -14,14 +14,20 @@ models:
     fields:
       - type: string
         name: layout
+        label: Layout
+        const: post
       - type: string
         name: title
+        label: Title
       - type: string
         name: author
+        label: Author
       - type: string
         name: meta
+        label: Meta
       - type: string
         name: categories
+        label: Categories
   basicpage:
     type: page
     label: Basic Page
@@ -32,13 +38,17 @@ models:
     fields:
       - type: string
         name: layout
+        label: Layout
   homepage:
     type: page
     label: Homepage
     file: index.md
+    singleInstance: true
     fields:
       - type: string
         name: layout
+        label: Layout
+        const: home
   config:
     type: data
     label: Config
@@ -46,45 +56,63 @@ models:
     fields:
       - type: string
         name: title
+        label: Title
       - type: string
         name: author
+        label: Author Name
       - type: string
         name: email
+        label: Email
       - type: string
         name: url
-      - type: string
-        name: url
+        label: URL
+        description: Site root url
       - type: string
         name: description
+        label: Description
       - type: string
         name: favicon
+        label: Favicon
       - type: boolean
         name: show_excerpts
+        label: Show Excerpts
       - type: object
         name: moving
+        label: Moving
         fields:
           - type: string
             name: avatar_url
+            label: Avatar URL
           - type: string
             name: about_you
+            label: About You
           - type: string
             name: date_format
+            label: Date Format
           - type: string
             name: back_to
+            label: Back Button Label
           - type: object
             name: social_links
+            label: Social Links
             fields:
               - type: string
                 name: github
+                label: Github
               - type: string
                 name: rss
+                label: RSS
               - type: string
                 name: facebook
+                label: Facebook
               - type: string
                 name: linkedin
+                label: Linkedin
       - type: string
         name: theme
+        label: Theme
       - type: list
         name: plugins
+        label: Plugins
         items:
           type: string

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -1,0 +1,84 @@
+stackbitVersion: "~0.2.0"
+ssgName: custom
+staticDir: ""
+uploadDir: images
+buildCommand: "bundle install && jekyll build"
+publishDir: "_site"
+dataDir: "_data"
+pagesDir: ""
+models:
+  post:
+    type: page
+    label: Post
+    folder: _posts
+    fields:
+      - type: string
+        name: layout
+      - type: string
+        name: title
+      - type: string
+        name: author
+      - type: string
+        name: meta
+      - type: string
+        name: categories
+  basicpage:
+    type: page
+    label: Basic Page
+    match: "*.md"
+    exclude:
+      - "README.md"
+      - "index.md"
+    fields:
+      - type: string
+        name: layout
+  homepage:
+    type: page
+    label: Homepage
+    file: index.md
+    fields:
+      - type: string
+        name: layout
+  config:
+    type: data
+    label: Config
+    file: "_config.yml"
+    fields:
+      - type: string
+        name: title
+      - type: string
+        name: author
+      - type: string
+        name: email
+      - type: string
+        name: url
+      - type: string
+        name: url
+      - type: string
+        name: description
+      - type: string
+        name: favicon
+      - type: boolean
+        name: show_excerpts
+      - type: object
+        name: moving
+        fields:
+          - type: string
+            name: avatar_url
+          - type: string
+            name: about_you
+          - type: string
+            name: date_format
+          - type: string
+            name: back_to
+          - type: object
+            name: social_links
+            fields:
+              - type: string
+                name: github
+              - type: string
+                name: rss
+              - type: string
+                name: facebook
+              - type: string
+                name: linkedin

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -83,7 +83,7 @@ models:
               - type: string
                 name: linkedin
       - type: string
-        name: moving
+        name: theme
       - type: list
         name: plugins
         items:

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -4,7 +4,7 @@ staticDir: ""
 uploadDir: images
 buildCommand: "bundle install && jekyll build"
 publishDir: "_site"
-dataDir: "_data"
+dataDir: ""
 pagesDir: ""
 models:
   post:
@@ -82,3 +82,9 @@ models:
                 name: facebook
               - type: string
                 name: linkedin
+      - type: string
+        name: moving
+      - type: list
+        name: plugins
+        items:
+          type: string

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -28,17 +28,16 @@ models:
       - type: string
         name: categories
         label: Categories
-  basicpage:
+  aboutpage:
     type: page
-    label: Basic Page
-    match: "*.md"
-    exclude:
-      - "README.md"
-      - "index.md"
+    label: AboutPage
+    file: about.md
+    singleInstance: true
     fields:
       - type: string
         name: layout
         label: Layout
+        const: about
   homepage:
     type: page
     label: Homepage


### PR DESCRIPTION
This pull request add's Stackbit to this theme. It add's the stackbit.yaml file which makes this theme work with several headless CMS automatically (including Forestry, NetlifyCMS, DatoCMS & Contentful) and it deploys the site to Netlify in 1 click.

You can try it out: https://app.stackbit.com/create?theme=https://github.com/stackbithq/moving (note the "create with stackbit" button in the readme will import the theme from your repo so until the PR is merged it wont work)

Hope you think it's as awesome as i do!
