### PR TITLE
fix: load highlight.min.js via https

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,7 +6,7 @@
   <link rel="stylesheet" href="{{ site.url }}/assets/css/main.css" />
   <link rel="shortcut icon" type="image/x-icon" href="/{{ site.favicon }}" />
   <link rel="stylesheet" href="{{ site.url }}/assets/css/agate.css" />
-  <script src="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.4.0/highlight.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.4.0/highlight.min.js"></script>
   <script>
     hljs.initHighlightingOnLoad();
   </script>


### PR DESCRIPTION
Because it fails to load on https sites with mixed active content warnings.

![2019-08-28-120828_1096x233_scrot](https://user-images.githubusercontent.com/7799664/63885155-97268800-c98c-11e9-8e47-ae5746da5518.png)
