### PR TITLE
fix: drop .html suffix from about url

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,7 +6,7 @@
           <ul class="contact-list">
             <li class="p-name">
               {%- if site.author -%}
-                <a class="black-link" href="{{ site.url }}/about.html">
+                <a class="black-link" href="{{ site.url }}/about">
                   {{ site.author | escape }} 
                 </a>
               {%- endif -%}


### PR DESCRIPTION
To support jekyll projects where the urls don't have any suffix.
This should still work on exists projects.