### PR TITLE
[fix] Fixed fav icon not showing

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   {%- seo title=false -%}
   <link rel="stylesheet" href="{{ site.url }}/assets/css/main.css" />
-  <link rel="shortcut icon" type="image/x-icon" href="/{{ site.favicon }}" />
+  <link rel="shortcut icon" type="image/x-icon" href="/{{ site.favicon }}?" />
   <link rel="stylesheet" href="{{ site.url }}/assets/css/agate.css" />
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.4.0/highlight.min.js"></script>
   <script>

--- a/moving.gemspec
+++ b/moving.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "jekyll-feed", "~> 0.9"
   spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.1"
 
-  spec.add_development_dependency "bundler", "~> 2.0.2"
+  spec.add_development_dependency "bundler", "~> 2.1.4"
   spec.add_development_dependency "rake", "~> 12.0"
 end


### PR DESCRIPTION
- Changed bundler to 2.1.4

Cloning your repo and testing the deault settings, didn't show the Fav Icon at all, at least to me. I fixed that :) 